### PR TITLE
Fix injection and selectors for follow/scroll

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -49,11 +49,20 @@ document.addEventListener('DOMContentLoaded', () => {
     function executeScript(func, args = []) {
         chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
             if (tabs.length === 0) return;
+            const tabId = tabs[0].id;
+
+            // Zuerst content.js in die Seite injizieren, damit alle Helferfunktionen
+            // vorhanden sind. Anschließend die gewünschte Funktion ausführen.
             chrome.scripting.executeScript({
-                target: { tabId: tabs[0].id },
-                func: func,
-                args: args
-            }).catch(err => console.error("Skript-Fehler:", err));
+                target: { tabId },
+                files: ['content.js']
+            }, () => {
+                chrome.scripting.executeScript({
+                    target: { tabId },
+                    func: func,
+                    args: args
+                }).catch(err => console.error('Skript-Fehler:', err));
+            });
         });
     }
 


### PR DESCRIPTION
## Summary
- inject `content.js` into the active tab before executing any helper function
- support updated follow-list selectors
- add robust lookup for the "next video" button when scrolling

## Testing
- `node --check content.js`
- `node --check popup.js`


------
https://chatgpt.com/codex/tasks/task_e_68451ba529b08325980f698e9d9fb690